### PR TITLE
add ostruct dep (removed in Ruby 3.5)

### DIFF
--- a/gemspec.yml
+++ b/gemspec.yml
@@ -21,3 +21,6 @@ required_ruby_version: ">= 2.0.0"
 
 development_dependencies:
   bundler: ~> 2.0
+
+dependencies:
+  ostruct: ~> 0.6


### PR DESCRIPTION
Fix `warning: ostruct used to be loaded from the standard library, but is not part of the default gems since Ruby 3.5.0` on 3.5.0-preview1